### PR TITLE
修复使用 base64 发送图片时格式错误的问题

### DIFF
--- a/utils/translator.py
+++ b/utils/translator.py
@@ -151,7 +151,7 @@ async def translate_message_array(_message: list) -> list:      # v11 -> v12
                 elif item["data"]["file"].startswith("base64"):
                     message[i]["data"]["file_id"] = (await file.upload_file(
                         "data",
-                        f"{int(time.time())}",
+                        f"{int(time.time())}{config['system'].get('base64_default_image_type', '.png')}",
                         data=item["data"]["file"][9:]
                     ))["data"]["file_id"]
                 if item["type"] == "record":


### PR DESCRIPTION
修复在 OneBot V11 中使用 base64 发送图片无法被 Discord 正常识别的问题
