### PR TITLE
修复参数为 None 时传递出错的问题

### DIFF
--- a/utils/commands.py
+++ b/utils/commands.py
@@ -24,7 +24,7 @@ async def handle_command(interaction: Interaction, args: Optional[str]) -> None:
     if not (user := client.get_user(interaction.user.id)):
         return    
     
-    content = f"{config['system'].get('prefix', '/')}{interaction.command.name} {args}"
+    content = f"{config['system'].get('prefix', '/')}{interaction.command.name} {args or ''}"
     await interaction.response.defer()
     session_id = str(interaction.channel_id or interaction.user.id)
     if session_id in deferred_sessions:


### PR DESCRIPTION
修复使用 Discord 斜线命令时，不指定 args 参数时参数会被解析成 None 的问题

如，使用 `/help` 时，OneDisc 向 WebSocket 发送的是 `/help None`