### PR TITLE
使用数据库代替部分 `cached_messages`

### DIFF
--- a/actions/v12/extra.py
+++ b/actions/v12/extra.py
@@ -1,29 +1,31 @@
-from utils.config import config
+from utils import discord_api
 import utils.message.v12.parser as parser
 import utils.return_object as return_object
 from actions import register_action
-from utils.client import client
+from utils.db import get_session, Message
 
 
 @register_action()
 async def edit_message(message_id: str, content: list) -> dict:
-    for message in client.cached_messages:
-        if message.id == int(message_id):
-            await message.edit(content=(await parser.parse_message(content))["content"])
-            return return_object.get(0)
-    return return_object.get(35002, f"消息 {message_id} 不存在")
+    async with get_session() as session:
+        message = await session.get_one(
+            Message,
+            int(message_id)
+        )
+    await discord_api.call(
+        "PATCH",
+        f"/channels/{message.channel}/messages/{message.id}",
+        await parser.parse_message(content)
+    )
+    return return_object.get(0)
+
 
 
 @register_action()
 async def call_api(endpoint: str, method: str, data: dict) -> dict:
-    async with httpx.AsyncClient(proxies=config["system"]["proxy"]) as client:
-        response = await client.request(
-            method,
-            f"https://discord.com/api/v9/{endpoint}",
-            json=data
-        )
+    response = await discord_api.call(method, endpoint, data)
     return return_object.get(
         0,
-        status_code=response.status_code,
-        response=response.json()
+        status_code=response["code"],
+        response=response
     )

--- a/call_action.py
+++ b/call_action.py
@@ -5,6 +5,7 @@ import utils.return_object as return_object
 from utils.type_checker import BadParam
 from utils.logger import get_logger
 import traceback
+from utils.discord_api import DiscordApiException
 from utils.message.v12.parser import UnsupportedSegment, BadSegmentData
 import random
 from utils.config import config
@@ -48,6 +49,11 @@ async def on_call_action(action: str, params: dict, echo: str | None = None, pro
         return return_object.get(10006, str(e))
     except BadParam as e:
         return return_object.get(10003, str(e))
+    except DiscordApiException as e:
+        return return_object.get(
+            34002,
+            e.message
+        )
     except Exception as e:
         logger.error(traceback.format_exc())
         return_data = return_object.get(20002, str(e))

--- a/docs/config.md
+++ b/docs/config.md
@@ -82,6 +82,21 @@ OneDisc 高级设置（无特殊需要不建议更改）
 
 将合并转发消息渲染为图片缓存并发送时使用的图片类型
 
+
+### 数据库地址（`database`）
+
+| 类型       | 必须 | 默认值                 |
+|:----------:|:----:|:----------------------:|
+| 字符串      | 否   | `sqlite+aiosqlite:///:memory:` |
+
+OneDisc 缓存消息使用的数据库地址
+
+参考 [Engine Configuration — SQLAlchemy 2.0 Documentation](https://docs.sqlalchemy.org/en/20/core/engines.html#database-urls)
+
+不支持自动创建数据库
+
+> 目前可执行版只支持 SQLite3，源码版使用其他数据库需要手动安装依赖
+
 ### 使用静态表情（`use_static_face`）
 
 | 类型       | 必须 | 默认值                 |

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,5 @@ httpx
 aiohttp>=3.7.4,<4
 imgkit
 websockets
+sqlalchemy
+aiosqlite

--- a/utils/client.py
+++ b/utils/client.py
@@ -13,3 +13,4 @@ client = Client(
     proxy=config["system"]["proxy"]
 )
 tree = app_commands.CommandTree(client)
+

--- a/utils/db.py
+++ b/utils/db.py
@@ -1,0 +1,42 @@
+from traceback import format_exc
+from sqlalchemy.ext.asyncio import create_async_engine, AsyncSession
+from sqlalchemy.orm import declarative_base
+from sqlalchemy import Column, Integer
+from .config import config
+from .logger import get_logger
+
+logger = get_logger()
+Base = declarative_base()
+db_url = config["system"].get("database", "sqlite+aiosqlite:///:memory:")
+logger.debug(f'使用数据库: {db_url}')
+engine = create_async_engine(db_url)
+del db_url
+
+
+class Message(Base):
+    __tablename__ = "message"
+    id = Column(Integer, primary_key=True)
+    channel = Column(Integer)
+    time = Column(Integer)
+
+async def init_database() -> None:
+    async with engine.connect() as conn:
+        await conn.run_sync(Message.metadata.create_all)
+    logger.info("数据库初始化完成！")
+
+def get_session() -> AsyncSession:
+    return AsyncSession(engine)
+
+async def commit_message(id_: int, channel: int, time_: int) -> None:
+    async with get_session() as session:
+        try:
+            session.add(Message(
+                id=id_,
+                channel=channel,
+                time=time_
+            ))
+        except Exception:
+            await session.rollback()
+            logger.warning(f"写入数据库失败: {format_exc()}")
+        else:
+            await session.commit()

--- a/utils/discord_api.py
+++ b/utils/discord_api.py
@@ -14,10 +14,10 @@ class DiscordApiException(Exception):
         logger.warning(f"调用 Discord API 时出现错误（{self.code}）：\n{json.dumps(self.data, indent=4)}")
 
 async def call(method: str, path: str, data: dict | None = None, **params) -> dict:
-    async with httpx.AsyncClient(proxies=config["system"].get("proxy")) as client:
+    async with httpx.AsyncClient(proxies=config["system"].get("proxy"), base_url="https://discord.com/api/v10") as client:
         response = await client.request(
             method,
-            f"https://discord.com/api/v10{path}",
+            path,
             data=data,
             headers={"Authorization": f"Bot {config['account_token']}"},
             **params

--- a/utils/discord_api.py
+++ b/utils/discord_api.py
@@ -24,4 +24,8 @@ async def call(method: str, path: str, data: dict | None = None, **params) -> di
         )
     if response.status_code == 400:
         raise DiscordApiException(response.json())
+    elif response.status_code == 204:
+        return {
+            "code": 204
+        }
     return response.json()

--- a/utils/discord_api.py
+++ b/utils/discord_api.py
@@ -1,0 +1,27 @@
+import json
+import httpx
+from .config import config
+from .logger import get_logger
+
+logger = get_logger()
+
+class DiscordApiException(Exception):
+    def __init__(self, data: dict) -> None:
+        super().__init__(data)
+        self.code = data["code"]
+        self.message = data["message"]
+        self.data = data
+        logger.warning(f"调用 Discord API 时出现错误（{self.code}）：\n{json.dumps(self.data, indent=4)}")
+
+async def call(method: str, path: str, data: dict | None = None, **params) -> dict:
+    async with httpx.AsyncClient(proxies=config["system"].get("proxy")) as client:
+        response = await client.request(
+            method,
+            f"https://discord.com/api/v10{path}",
+            data=data,
+            headers={"Authorization": f"Bot {config['account_token']}"},
+            **params
+        )
+    if response.status_code == 400:
+        raise DiscordApiException(response.json())
+    return response.json()

--- a/utils/event/discord_event.py
+++ b/utils/event/discord_event.py
@@ -7,7 +7,7 @@ import utils.event as event
 import discord
 from discord import Object
 import asyncio
-
+from ..db import commit_message, init_database
 from utils.update_checker import check_update
 from actions.v12.basic import get_status
 from actions.v11.basic import get_role
@@ -38,6 +38,7 @@ async def on_ready() -> None:
     )
     if config["system"].get("check_update", True):
         asyncio.create_task(check_update())
+    await init_database()
 
 
 @client.event
@@ -45,6 +46,7 @@ async def on_message(message: discord.Message) -> None:
     if message.author == client.user and config["system"].get("ignore_self_events", True):
         return
     print_message_log(message)
+    await commit_message(message.id, message.channel.id, int(message.created_at.timestamp()))
     if message.guild and config["system"].get("enable_channel_event"):
         event.new_event(
             _type="message",

--- a/utils/logger.py
+++ b/utils/logger.py
@@ -48,12 +48,12 @@ def print_message_delete_log(message: discord.Message) -> None:
     except AttributeError:
         logger.info(f"{message.author.name}({message.author.id}) 撤回了消息：{message.content}")
 
-def discord_api_failed(response: httpx.Response) -> dict:
-    body = json.loads(response.read())
-    logger.warning(f"调用 Discord API 时出现错误（{body['cdoe']}）：\n{json.dumps(body, indent=4)}")
-    return {
-        "status": "failed",
-        "retcode": 34002,
-        "data": None,
-        "message": body["message"]
-    }
+# def discord_api_failed(response: httpx.Response) -> dict:
+#     body = json.loads(response.read())
+#     logger.warning(f"调用 Discord API 时出现错误（{body['code']}）：\n{json.dumps(body, indent=4)}")
+#     return {
+#         "status": "failed",
+#         "retcode": 34002,
+#         "data": None,
+#         "message": body["message"]
+#     }

--- a/utils/message/v12/parser.py
+++ b/utils/message/v12/parser.py
@@ -202,3 +202,14 @@ def parse_string(string: str, msg: discord.Message | None = None) -> list:
             message.append({"type": "file", "data": {"file_id": file.create_url_cache(attachment.filename, attachment.url)}})
     logger.debug(message)
     return message
+
+def parse_dict_message(msg: dict) -> list:
+    message = parse_string(msg["content"])
+    for attachment in msg["attachments"]:
+        for file_type in ["image", "video", "audio"]:
+            if attachment["content_type"].startswith(file_type):
+                message.append({"type": file_type, "data": {"file_id": file.create_url_cache(attachment["filename"], attachment["url"])}})
+                break
+        else:
+            message.append({"type": "file", "data": {"file_id": file.create_url_cache(attachment["filename"], attachment["url"])}})
+    return message


### PR DESCRIPTION
- 使用数据库替代部分 `client.cached_message` #28
- 修复 `discord_api.call` 在 API 返回 204 时报错的问题

使用数据库储存消息来并代替部分 `client.cached_message`

并独立直接调用 Discord API 的代码
