### PR TITLE
允许自定义反向 WS 中最大包大小

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -145,6 +145,20 @@ wkhtmltopdf 可执行程序路径
 
 `can_send_record` (OneBot V11) 接口中 `yes` 字段内容
 
+### 反向 WebSocket 最大消息大小（`max_message_size`）
+
+| 类型       | 必须 | 默认值                 |
+|:----------:|:----:|:----------------------:|
+| 数字       | 否   | `1048576`               |
+
+OneBot V11 和 OneBot V12 的反向 WebSocket 连接中最大消息大小，单位为字节，默认 1MB（即 `2^20`）
+
+如果在使用过程中出现以下错误请考虑增大这一配置项的数值: 
+
+```python
+websockets.exceptions.ConnectionClosedError: sent 1009 (message too big); no close frame received
+```
+
 ### 跳过参数类型检查（`skip_params_type_checking`）
 
 
@@ -410,7 +424,13 @@ OneDisc 完成启动后打印的日志的内容
 
 ### OneBot V11
 
-> 在所有采用 OneBot V11 标准的连接中，请确保指定 `"protocol_version": 11`（默认值为 `12` ）。若不正确设定，将会收到「无效的连接类型或协议版本」的提示。
+::: tip
+
+在所有采用 OneBot V11 标准的连接中，请确保指定 `"protocol_version": 11`（默认值为 `12` ）。
+
+若不正确设定，将会收到「无效的连接类型或协议版本」的提示。
+
+:::
 
 <details>
 <summary>HTTP</summary>

--- a/network/v11/ws_reverse.py
+++ b/network/v11/ws_reverse.py
@@ -1,10 +1,10 @@
-from typing import Callable, Coroutine, Literal
+from typing import Callable, Literal
+from utils.config import config as system_config
 from utils.client import client
 import utils.translator as translator
 import websockets
 import json
 import json
-import utils.event as event
 import call_action
 import asyncio
 import traceback
@@ -53,6 +53,7 @@ class WebSocketClient:
     async def create_connection(self) -> None:
         self.ws = await websockets.client.connect(
             self.get_url(),
+            max_size=system_config["system"].get("max_message_size", 2**20),
             extra_headers=self.get_headers()
         )
     

--- a/network/v12/ws_reverse.py
+++ b/network/v12/ws_reverse.py
@@ -3,7 +3,7 @@ import utils.event as event
 import call_action
 import asyncio
 import traceback
-
+from utils.config import config as system_config
 from utils.logger import get_logger
 from version import VERSION
 
@@ -29,7 +29,8 @@ class WebSocketClient:
         self.websocket = await websockets.client.connect(
             self.config["url"],
             user_agent_header=f"OneBot/12 (discord) OneDisc/{VERSION}",
-            extra_headers=self.get_headers()
+            extra_headers=self.get_headers(),
+            max_size=system_config["system"].get("max_message_size", 2**20),
         )
         logger.info(f"已连接到 WebSocket 服务器：{self.config['url']}")
         await self.send(event.get_event_object(


### PR DESCRIPTION
添加 `max_message_size` 配置项用于指定反向 WebSocket （OneBot V11/V12） 中连接的最大包大小

用于修复 WebSocket 连接的 1009 错误