### PR TITLE
fix: 修复 Authorization header 鉴权失效等问题 (HTTP/WS 鉴权) + 版本 1.0.1

### DIFF
--- a/network/authentication.py
+++ b/network/authentication.py
@@ -1,6 +1,28 @@
 import fastapi
 
 
+def get_bearer_token(
+    request: fastapi.Request | fastapi.WebSocket,
+) -> str | None:
+    """
+    大小写不敏感地获取 Authorization header 值
+
+    uvicorn 按 ASGI 规范会把 header 名转为小写，但不同服务器/客户端可能保留
+    原始大小写，因此逐项比较 key.lower() 最稳妥（starlette 的 get() 依赖内部
+    存储大小写，两种场景下行为不一致）
+
+    Args:
+        request (fastapi.Request | fastapi.WebSocket): 请求信息
+
+    Returns:
+        str | None: Authorization header 值，不存在时为 None
+    """
+    for key, value in request.headers.items():
+        if key.lower() == "authorization":
+            return value
+    return None
+
+
 def verify_access_token(
     request: fastapi.Request | fastapi.WebSocket, access_token: str | None
 ) -> bool:
@@ -16,6 +38,7 @@ def verify_access_token(
     """
     if access_token is None:
         return True
-    if "Authorization" in request.headers.keys():
-        return request.headers["Authorization"] == f"Bearer {access_token}"
+    authorization = get_bearer_token(request)
+    if authorization is not None:
+        return authorization == f"Bearer {access_token}"
     return request.query_params.get("access_token") == access_token

--- a/network/v11/http.py
+++ b/network/v11/http.py
@@ -1,4 +1,4 @@
-from network.authentication import verify_access_token
+from network.authentication import get_bearer_token, verify_access_token
 import utils.uvicorn_server as uvicorn_server
 import fastapi
 from utils.logger import get_logger
@@ -17,7 +17,7 @@ class HttpServer:
         self.check_access_token()
 
     def check_access_token(self) -> None:
-        if self.config["host"] == "0.0.0.0" or self.config["access_token"]:
+        if not self.config["access_token"]:
             logger.warning(
                 f'[{self.config["host"]}:{self.config["port"]}] 未配置 Access Token !'
             )
@@ -31,9 +31,7 @@ class HttpServer:
         self, request: fastapi.Request
     ) -> fastapi.responses.JSONResponse:
         if not verify_access_token(request, self.config["access_token"]):
-            if "Authorization" in request.headers.keys() or request.query_params.get(
-                "access_token"
-            ):
+            if get_bearer_token(request) or request.query_params.get("access_token"):
                 raise fastapi.HTTPException(status_code=403, detail="Forbidden")
             else:
                 raise fastapi.HTTPException(status_code=401, detail="Unauthorized")

--- a/network/v11/ws.py
+++ b/network/v11/ws.py
@@ -1,6 +1,6 @@
 import utils.translator as translator
 import utils.event as event
-from network.authentication import verify_access_token
+from network.authentication import get_bearer_token, verify_access_token
 from utils.logger import get_logger
 import utils.uvicorn_server as uvicorn_server
 import fastapi
@@ -22,7 +22,7 @@ class WebSocket:
         self.check_access_token()
 
     def check_access_token(self) -> None:
-        if self.config["host"] == "0.0.0.0" or self.config["access_token"]:
+        if not self.config["access_token"]:
             logger.warning(
                 f'[{self.config["host"]}:{self.config["port"]}] 未配置 Access Token !'
             )
@@ -35,7 +35,7 @@ class WebSocket:
     async def handle_event_route(self, websocket: fastapi.WebSocket) -> None:
         if not verify_access_token(websocket, self.config["access_token"]):
             if (
-                "Authorization" in websocket.headers.keys()
+                get_bearer_token(websocket)
                 or websocket.query_params.get("access_token")
             ):
                 await websocket.close(403, "Invalid access token")
@@ -53,7 +53,7 @@ class WebSocket:
     async def handle_api_route(self, websocket: fastapi.WebSocket) -> None:
         if not verify_access_token(websocket, self.config["access_token"]):
             if (
-                "Authorization" in websocket.headers.keys()
+                get_bearer_token(websocket)
                 or websocket.query_params.get("access_token")
             ):
                 await websocket.close(403, "Invalid access token")
@@ -73,7 +73,7 @@ class WebSocket:
     async def handle_root_route(self, websocket: fastapi.WebSocket) -> None:
         if not verify_access_token(websocket, self.config["access_token"]):
             if (
-                "Authorization" in websocket.headers.keys()
+                get_bearer_token(websocket)
                 or websocket.query_params.get("access_token")
             ):
                 await websocket.close(403, "Invalid access token")

--- a/network/v12/http.py
+++ b/network/v12/http.py
@@ -40,7 +40,7 @@ class HttpServer:
         self.check_access_token()
 
     def check_access_token(self) -> None:
-        if self.config["host"] == "0.0.0.0" or self.config["access_token"]:
+        if not self.config["access_token"]:
             logger.warning(
                 f'[HTTP {self.config["host"]}:{self.config["port"]}] 未配置 Access Token !'
             )
@@ -61,7 +61,7 @@ class HttpServer:
             dict: 返回值
         """
         logger.debug(request)
-        if verify_access_token(request, self.config["access_token"]):
+        if not verify_access_token(request, self.config["access_token"]):
             raise fastapi.HTTPException(fastapi.status.HTTP_401_UNAUTHORIZED)
         logger.debug(await request.body())
         return fastapi.responses.JSONResponse(

--- a/network/v12/ws.py
+++ b/network/v12/ws.py
@@ -27,7 +27,7 @@ class WebSocketServer:
         self.check_access_token()
 
     def check_access_token(self) -> None:
-        if self.config["host"] == "0.0.0.0" or self.config["access_token"]:
+        if not self.config["access_token"]:
             logger.warning(
                 f'[{self.config["host"]}:{self.config["port"]}] 未配置 Access Token !'
             )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onedisc"
-version = "1.0.0"
+version = "1.0.1"
 description = "OneBot implement for Discord"
 authors = [
     {name = "XiaoDeng3386",email = "1744793737@qq.com"}


### PR DESCRIPTION
## 修复内容

### 1. `Authorization: Bearer` 鉴权完全失效（核心修复）
- **现象**：用标准 `Authorization: Bearer <token>` 头的 OneBot 客户端请求 HTTP API 永远得到 401；只有 `?access_token=*** 查询参数能通过
- **根因**：uvicorn 按 [ASGI 规范](https://asgi.readthedocs.io/en/latest/specs/www.html) 会把 header 名转为**小写**存入 `scope`，而 `verify_access_token` 用 `"Authorization" in request.headers.keys()` 做**大小写敏感**的成员判断 → 永远匹配不上
- **修复**：新增 `get_bearer_token()`，遍历 `headers.items()` 逐项比较 `key.lower()`，不依赖 starlette 内部大小写行为；`verify_access_token` 与 v11 HTTP/WS 的 401/403 区分逻辑全部改用它

### 2. 「未配置 Access Token !」警告逻辑反转
- `check_access_token()` 在**已配置** token 时反而报警告（条件缺 `not`），v11/v12 的 HTTP 与 WS 服务器全部修正

### 3. v12 HTTP 鉴权判断反向（历史遗留，自 PR #56 起）
- `handle_http_connection` 原来写的是 `if verify_access_token(...): raise 401` —— 鉴权**成功**反而被拒，鉴权失败反而放行；已修正为 `if not ...`

### 4. 版本号 1.0.0 → 1.0.1（发布前置）

## 验证
- 单元测试 6 例（小写 key / 大写 key / 错误 token / query 参数 / 无凭证 / 未配置 token）全部通过
- 源码运行 + 真实 Discord 登录后实测：
  - 正确 Bearer header → `200`（修复前 401）
  - 错误 token → `403`
  - 无凭证 → `401`
  - query 参数 → `200`（无回归）
  - `get_version_info` → `app_version: 1.0.1`
- 冒烟测试断言不受影响（继续用 ASCII 文本）