### PR TITLE
ci: 构建前安装 zstandard，启用 Nuitka onefile 压缩（Linux 产物 250MB → ~40MB）

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -69,6 +69,11 @@ jobs:
         run: |
           poetry install --all-groups
 
+      - name: "Install zstandard (Nuitka onefile compression)"
+        shell: bash
+        run: |
+          poetry run pip install zstandard
+
       - name: "Build with Nuitka"
         shell: bash
         run: |
@@ -192,6 +197,11 @@ jobs:
         run: |
           poetry install --all-groups
 
+      - name: "Install zstandard (Nuitka onefile compression)"
+        shell: bash
+        run: |
+          poetry run pip install zstandard
+
       - name: "Build with Nuitka"
         run: |
           poetry run python -m nuitka \
@@ -304,6 +314,11 @@ jobs:
       - name: "Install dependencies"
         run: |
           poetry install --all-groups
+
+      - name: "Install zstandard (Nuitka onefile compression)"
+        shell: bash
+        run: |
+          poetry run pip install zstandard
 
       - name: "Build with Nuitka"
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,6 +75,11 @@ jobs:
         run: |
           poetry install --all-groups
 
+      - name: "Install zstandard (Nuitka onefile compression)"
+        shell: bash
+        run: |
+          poetry run pip install zstandard
+
       - name: "Build with Nuitka"
         shell: bash
         run: |
@@ -199,6 +204,11 @@ jobs:
         run: |
           poetry install --all-groups
 
+      - name: "Install zstandard (Nuitka onefile compression)"
+        shell: bash
+        run: |
+          poetry run pip install zstandard
+
       - name: "Build with Nuitka"
         run: |
           poetry run python -m nuitka \
@@ -319,6 +329,11 @@ jobs:
       - name: "Install dependencies"
         run: |
           poetry install --all-groups
+
+      - name: "Install zstandard (Nuitka onefile compression)"
+        shell: bash
+        run: |
+          poetry run pip install zstandard
 
       - name: "Build with Nuitka"
         run: |


### PR DESCRIPTION
## 问题
Linux 产物 250MB，Windows/macOS 仅 ~37MB。

根因：Nuitka onefile 默认用 zstandard 压缩 payload，但 Ubuntu runner 上没有
带 zstandard 的 Python 可用，构建日志警告：
`Onefile mode cannot compress without 'zstandard' package installed`，
payload 原样打包（已确认二进制内 0 个 zstd 魔数）。

## 修复
每个构建 job 在 Nuitka 编译前增加 `poetry run pip install zstandard`。
Nuitka 的 `findInstalledPython` 会优先扫描当前 Python，安装后即可启用压缩。

## 预期
Linux 产物从 250MB 压缩到 ~40MB 级别，运行时行为不变（onefile 自动解压）。