### PR TITLE
fix: 修复 WebSocket 反向连接断开后无法正确重连的问题

### DIFF
--- a/network/v11/ws_reverse.py
+++ b/network/v11/ws_reverse.py
@@ -65,7 +65,14 @@ class WebSocketClient:
         )
 
     async def reconnect(self) -> None:
-        # 但愿别 tm 出 bug
+        # 先关闭旧连接，避免下游服务器保留旧连接拒绝新连接
+        if hasattr(self, "ws"):
+            try:
+                await self.ws.close()
+            except Exception:
+                pass  # 忽略关闭时的错误
+            self.ws = None
+
         if not self.connect_task:
             self.connect_task = asyncio.create_task(self.connect())
         await self.connect_task
@@ -141,9 +148,22 @@ class EventClient(WebSocketClient):
         self.role = "Event"
 
     async def push_event(self, event: dict) -> None:
-        if not hasattr(self, "ws"):
+        if not self.is_ready():
             await self.reconnect()
-        await self.ws.send(json.dumps(await translator.translate_event(event)))
+        try:
+            await self.ws.send(json.dumps(await translator.translate_event(event)))
+        except websockets.exceptions.ConnectionClosedError:
+            logger.warning(
+                f"从反向 WebSocket {self.role} 断开连接: {traceback.format_exc()}"
+            )
+            await self.reconnect()
+            # 重连后重试发送
+            try:
+                await self.ws.send(json.dumps(await translator.translate_event(event)))
+            except Exception:
+                logger.error(
+                    f"重连后发送事件失败: {traceback.format_exc()}"
+                )
 
 
 class UniversalClient(APIClient, EventClient):


### PR DESCRIPTION
## 问题描述

OneBot 11 的 ws-reserve 在因为各种原因断开连接时，WebSocket 连接会失去原子性，导致：

1. `EventClient.push_event()` 方法没有处理 `ConnectionClosedError` 异常
2. 当 WebSocket 因 keepalive ping 超时断开后，任务异常未被捕获（"Task exception was never retrieved"）
3. 重连时没有关闭旧连接，下游 NoneBot2 会显示已有连接而拒绝新的连接

## 修复方案

1. 在 `EventClient.push_event()` 中添加 `ConnectionClosedError` 异常处理
2. 在 `reconnect()` 中先关闭旧连接再建立新连接，避免下游服务器保留旧连接拒绝新连接
3. 修复了 WebSocket 因 keepalive ping 超时断开后任务异常未被捕获的问题

## 修改文件

- `network/v11/ws_reverse.py`

## 测试

- 已在本地验证代码修改正确
- 建议在实际环境中测试 WebSocket 断开重连功能
